### PR TITLE
Add lazy.nvim installation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # codeexplain.nvim
 
-codeexplain.nvim is a NeoVim plugin that uses the powerful [GPT4ALL](https://gpt4all.io/) language model to provide on-the-fly, line-by-line explanations and potential security vulnerabilities for selected code directly in your NeoVim editor. It's like having your personal code assistant right inside your editor without leaking your codebase to any company.
+`codeexplain.nvim` is a Neovim plugin that uses the powerful [GPT4ALL](https://gpt4all.io/) language model to provide on-the-fly, line-by-line explanations and potential security vulnerabilities for selected code directly in your Neovim editor. It's like having your personal code assistant right inside your editor without leaking your codebase to any company.
 
 ![Demo](https://github.com/mthbernardes/codeexplain.nvim/assets/12648924/734f1687-d506-4b0b-9dd0-6e9232284e09)
 
 ## Features
+
 - No internet necessary
 - Automatic language detection for explaining code.
 - Supports a wide range of programming languages.
 - Powered by [GPT4ALL](https://gpt4all.io/) for code explanation.
 - Identification of potential security vulnerabilities.
-- Creates a new NeoVim window to display the explanations.
+- Creates a new Neovim window to display the explanations.
 
 ## Installation
 
 ## Requirements
-- NeoVim
+
+- Neovim
 - Python3
 - langchain
 - llama-cpp-python
@@ -25,7 +27,9 @@ codeexplain.nvim is a NeoVim plugin that uses the powerful [GPT4ALL](https://gpt
 ```bash
 pip install -r langchain==0.0.177 llama-cpp-python==0.1.48 Pygments==2.15.1 pynvim==0.4.3
 ```
+
 ### Download the GPT4ALL model
+
 Before installing the plugin, download the GPT4ALL model and save it in your home directory:
 
 ```bash
@@ -41,7 +45,7 @@ Add the following line to your `init.vim`:
 Plug 'mthbernardes/codeexplain.nvim'
 ```
 
-Then run the following commands in your NeoVim editor:
+Then run the following commands in your Neovim editor:
 
 ```vim
 :source %
@@ -56,24 +60,38 @@ Add the following to your `plugins.lua` file:
 use 'mthbernardes/codeexplain.nvim'
 ```
 
-Then run `PackerSync` in your NeoVim editor.
+Then run `PackerSync` in your Neovim editor.
+
+### lazy.nvim
+
+```lua
+{
+  "mthbernardes/codeexplain.nvim",
+  lazy = true,
+  cmd = "CodeExplain",
+  build = function()
+    vim.cmd([[silent UpdateRemotePlugins]])
+  end,
+}
+```
 
 ### Other package managers
 
 Please refer to your package manager's documentation for installation instructions. The general process involves adding a line to your `init.vim` (or equivalent configuration file) and running an installation command.
 
 ### Post-install
+
 Once installed execute the command `:UpdateRemotePlugins`
 
 ## Usage
+
 You can use the plugin by selecting a piece of code in Visual mode and running the `CodeExplain` command:
 
 ```vim
 :CodeExplain
 ```
 
-A new window will be opened in your NeoVim editor, displaying line-by-line explanations of the selected code and potential security vulnerabilities.
-
+A new window will be opened in your Neovim editor, displaying line-by-line explanations of the selected code and potential security vulnerabilities.
 
 ## Contributions
 


### PR DESCRIPTION
Add section for installation configuration with `lazy.nvim`

Also changed all occurrences of `NeoVim` to `Neovim`

Note that the `lazy.nvim` configuration automatically runs `UpdateRemotePlugins`

Thanks for this plugin. I finally got it working after your latest instructions, installing the specific versions of pip modules. I'm not happy with that solution but it is at least working now so I guess I am happy :+1: 